### PR TITLE
Fix localization of string resources in iOS

### DIFF
--- a/composeApp/src/commonMain/resources/MR/es/strings.xml
+++ b/composeApp/src/commonMain/resources/MR/es/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+    <string name="label_title">Título</string>
+    <string name="label_artist">Artista</string>
+    <string name="label_date">Fecha</string>
+    <string name="label_dimensions">Dimensiones</string>
+    <string name="label_medium">Medio</string>
+    <string name="label_department">Departmento</string>
+    <string name="label_repository">Repositorio</string>
+    <string name="label_credits">Créditos</string>
+
+    <string name="back">Atrás</string>
+
+    <string name="no_data_available">No hay datos disponibles</string>
+</resources>

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -46,5 +46,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>es</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
### Tasks
* Added Spanish translations. 
* Android worked without any other modifications.
* **Configured iOS app to handle the translations.**

### Evidence
| Android  | iOS |
| --- | --- |
| ![Android-Screenshot](https://github.com/Kotlin/KMP-App-Template/assets/4404680/d51267b7-3915-4d80-930c-f33136b97ef5) | ![iOS-Screenshot](https://github.com/Kotlin/KMP-App-Template/assets/4404680/da915272-07ea-4623-9798-0cd93f53b6d0) |