### PR TITLE
Koin Compiler Plugin & Annotations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,5 +3,6 @@ plugins {
     alias(libs.plugins.composeCompiler) apply false
     alias(libs.plugins.composeMultiplatform) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
+    alias(libs.plugins.koin) apply false
     alias(libs.plugins.kotlinxSerialization) apply false
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -57,6 +57,7 @@ kotlin {
             implementation(libs.coil.compose)
             implementation(libs.coil.network.ktor)
             implementation(libs.koin.compose.viewmodel)
+            implementation(libs.koin.annotations)
         }
     }
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.koin)
     alias(libs.plugins.kotlinxSerialization)
 }
 
@@ -55,7 +56,6 @@ kotlin {
 
             implementation(libs.coil.compose)
             implementation(libs.coil.network.ktor)
-            implementation(libs.koin.core)
             implementation(libs.koin.compose.viewmodel)
         }
     }
@@ -63,12 +63,12 @@ kotlin {
 
 android {
     namespace = "com.jetbrains.kmpapp"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.jetbrains.kmpapp"
         minSdk = 24
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
     }
@@ -86,6 +86,10 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
+}
+
+koinCompiler {
+    userLogs = true
 }
 
 dependencies {

--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/data/MuseumApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/data/MuseumApi.kt
@@ -4,11 +4,13 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.utils.io.CancellationException
+import org.koin.core.annotation.Singleton
 
 interface MuseumApi {
     suspend fun getData(): List<MuseumObject>
 }
 
+@Singleton
 class KtorMuseumApi(private val client: HttpClient) : MuseumApi {
     companion object {
         private const val API_URL =

--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/data/MuseumApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/data/MuseumApi.kt
@@ -10,6 +10,10 @@ interface MuseumApi {
     suspend fun getData(): List<MuseumObject>
 }
 
+/**
+ * Ktor-based implementation of [MuseumApi] for fetching museum data from remote API.
+ * Injected as singleton via @Singleton annotation.
+ */
 @Singleton
 class KtorMuseumApi(private val client: HttpClient) : MuseumApi {
     companion object {

--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/data/MuseumRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/data/MuseumRepository.kt
@@ -4,7 +4,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Singleton
 
+@Singleton
 class MuseumRepository(
     private val museumApi: MuseumApi,
     private val museumStorage: MuseumStorage,

--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/data/MuseumRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/data/MuseumRepository.kt
@@ -6,6 +6,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import org.koin.core.annotation.Singleton
 
+/**
+ * Repository for accessing and refreshing museum objects from API and storage.
+ * Injected as singleton via @Singleton annotation.
+ */
 @Singleton
 class MuseumRepository(
     private val museumApi: MuseumApi,

--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/data/MuseumRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/data/MuseumRepository.kt
@@ -11,6 +11,11 @@ class MuseumRepository(
 ) {
     private val scope = CoroutineScope(SupervisorJob())
 
+    // To see where we call this if not in constructor
+    init {
+        initialize()
+    }
+
     fun initialize() {
         scope.launch {
             refresh()

--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/data/MuseumStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/data/MuseumStorage.kt
@@ -13,6 +13,10 @@ interface MuseumStorage {
     fun getObjects(): Flow<List<MuseumObject>>
 }
 
+/**
+ * In-memory implementation of [MuseumStorage] for caching museum objects.
+ * Injected as singleton via @Singleton annotation.
+ */
 @Singleton
 class InMemoryMuseumStorage : MuseumStorage {
     private val storedObjects = MutableStateFlow(emptyList<MuseumObject>())

--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/data/MuseumStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/data/MuseumStorage.kt
@@ -3,6 +3,7 @@ package com.jetbrains.kmpapp.data
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
+import org.koin.core.annotation.Singleton
 
 interface MuseumStorage {
     suspend fun saveObjects(newObjects: List<MuseumObject>)
@@ -12,6 +13,7 @@ interface MuseumStorage {
     fun getObjects(): Flow<List<MuseumObject>>
 }
 
+@Singleton
 class InMemoryMuseumStorage : MuseumStorage {
     private val storedObjects = MutableStateFlow(emptyList<MuseumObject>())
 

--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/di/Koin.kt
@@ -35,11 +35,31 @@ import org.koin.plugin.module.dsl.startKoin
 //class AppModule
 
 // --- 1 module version ---
+/**
+ * Main Koin dependency injection module for the application.
+ *
+ * This module is responsible for providing all dependencies used throughout the app.
+ * It uses Koin's annotation-based configuration with:
+ * - [@Module][Module]: Marks this class as a Koin module
+ * - [@ComponentScan][ComponentScan]: Automatically scans and registers all annotated components
+ *   under the `com.jetbrains.kmpapp` package
+ * - [@Configuration][Configuration]: Indicates this is the root configuration module
+ */
 @Module
 @ComponentScan("com.jetbrains.kmpapp")
 @Configuration
 class AppModule {
 
+    /**
+     * Provides a configured [HttpClient] instance as a singleton.
+     *
+     * The client is configured with:
+     * - JSON serialization using kotlinx.serialization
+     * - `ignoreUnknownKeys = true` to gracefully handle API responses with extra fields
+     * - Content negotiation set to accept any content type (workaround for API not serving `application/json`)
+     *
+     * @return A configured [HttpClient] instance for making network requests
+     */
     @Singleton
     fun httpClient(): HttpClient {
         val json = Json { ignoreUnknownKeys = true }
@@ -52,9 +72,24 @@ class AppModule {
     }
 }
 
+/**
+ * Koin application entry point.
+ *
+ * This object is annotated with [@KoinApplication][KoinApplication] to generate
+ * the necessary Koin startup code at compile time using KSP (Kotlin Symbol Processing).
+ */
 @KoinApplication
 object KoinApp
 
+/**
+ * Initializes the Koin dependency injection framework.
+ *
+ * This function should be called once at application startup (typically in the
+ * platform-specific entry point) to set up all dependency injection bindings.
+ *
+ * @see KoinApp
+ * @see AppModule
+ */
 fun initKoin() {
     startKoin<KoinApp>()
 }

--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/di/Koin.kt
@@ -13,39 +13,38 @@ import io.ktor.http.ContentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import org.koin.core.context.startKoin
-import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.create
+import org.koin.plugin.module.dsl.single
+import org.koin.plugin.module.dsl.viewModel
 
 val dataModule = module {
-    single {
-        val json = Json { ignoreUnknownKeys = true }
-        HttpClient {
-            install(ContentNegotiation) {
-                // TODO Fix API so it serves application/json
-                json(json, contentType = ContentType.Any)
-            }
-        }
-    }
+    single { create(::buildHttpClient) }
+    single<KtorMuseumApi>() bind MuseumApi::class
+    single<InMemoryMuseumStorage>() bind MuseumStorage::class
+    single<MuseumRepository>()
+}
 
-    single<MuseumApi> { KtorMuseumApi(get()) }
-    single<MuseumStorage> { InMemoryMuseumStorage() }
-    single {
-        MuseumRepository(get(), get()).apply {
-            initialize()
+fun buildHttpClient(): HttpClient {
+    val json = Json { ignoreUnknownKeys = true }
+    return HttpClient {
+        install(ContentNegotiation) {
+            // TODO Fix API so it serves application/json
+            json(json, contentType = ContentType.Any)
         }
     }
 }
 
 val viewModelModule = module {
-    factoryOf(::ListViewModel)
-    factoryOf(::DetailViewModel)
+    viewModel<ListViewModel>()
+    viewModel<DetailViewModel>()
 }
+
+val appModule = module { includes(dataModule,viewModelModule) }
 
 fun initKoin() {
     startKoin {
-        modules(
-            dataModule,
-            viewModelModule,
-        )
+        modules(appModule)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/di/Koin.kt
@@ -1,50 +1,60 @@
 package com.jetbrains.kmpapp.di
 
-import com.jetbrains.kmpapp.data.InMemoryMuseumStorage
-import com.jetbrains.kmpapp.data.KtorMuseumApi
-import com.jetbrains.kmpapp.data.MuseumApi
-import com.jetbrains.kmpapp.data.MuseumRepository
-import com.jetbrains.kmpapp.data.MuseumStorage
-import com.jetbrains.kmpapp.screens.detail.DetailViewModel
-import com.jetbrains.kmpapp.screens.list.ListViewModel
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.ContentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
-import org.koin.core.context.startKoin
-import org.koin.dsl.bind
-import org.koin.dsl.module
-import org.koin.plugin.module.dsl.create
-import org.koin.plugin.module.dsl.single
-import org.koin.plugin.module.dsl.viewModel
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Configuration
+import org.koin.core.annotation.KoinApplication
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Singleton
+import org.koin.plugin.module.dsl.startKoin
 
-val dataModule = module {
-    single { create(::buildHttpClient) }
-    single<KtorMuseumApi>() bind MuseumApi::class
-    single<InMemoryMuseumStorage>() bind MuseumStorage::class
-    single<MuseumRepository>()
-}
+// --- 2 module version ---
+//@Module
+//@ComponentScan("com.jetbrains.kmpapp.data")
+//class DataModule {
+//
+//    @Singleton
+//    fun httpClient(): HttpClient {
+//        val json = Json { ignoreUnknownKeys = true }
+//        return HttpClient {
+//            install(ContentNegotiation) {
+//                // TODO Fix API so it serves application/json
+//                json(json, contentType = ContentType.Any)
+//            }
+//        }
+//    }
+//}
+//
+//@Module(includes = [DataModule::class])
+//@ComponentScan("com.jetbrains.kmpapp.screens")
+//@Configuration
+//class AppModule
 
-fun buildHttpClient(): HttpClient {
-    val json = Json { ignoreUnknownKeys = true }
-    return HttpClient {
-        install(ContentNegotiation) {
-            // TODO Fix API so it serves application/json
-            json(json, contentType = ContentType.Any)
+// --- 1 module version ---
+@Module
+@ComponentScan("com.jetbrains.kmpapp")
+@Configuration
+class AppModule {
+
+    @Singleton
+    fun httpClient(): HttpClient {
+        val json = Json { ignoreUnknownKeys = true }
+        return HttpClient {
+            install(ContentNegotiation) {
+                // TODO Fix API so it serves application/json
+                json(json, contentType = ContentType.Any)
+            }
         }
     }
 }
 
-val viewModelModule = module {
-    viewModel<ListViewModel>()
-    viewModel<DetailViewModel>()
-}
-
-val appModule = module { includes(dataModule,viewModelModule) }
+@KoinApplication
+object KoinApp
 
 fun initKoin() {
-    startKoin {
-        modules(appModule)
-    }
+    startKoin<KoinApp>()
 }

--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/screens/detail/DetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/screens/detail/DetailViewModel.kt
@@ -4,7 +4,9 @@ import androidx.lifecycle.ViewModel
 import com.jetbrains.kmpapp.data.MuseumObject
 import com.jetbrains.kmpapp.data.MuseumRepository
 import kotlinx.coroutines.flow.Flow
+import org.koin.core.annotation.KoinViewModel
 
+@KoinViewModel
 class DetailViewModel(private val museumRepository: MuseumRepository) : ViewModel() {
     fun getObject(objectId: Int): Flow<MuseumObject?> =
         museumRepository.getObjectById(objectId)

--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/screens/detail/DetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/screens/detail/DetailViewModel.kt
@@ -6,6 +6,10 @@ import com.jetbrains.kmpapp.data.MuseumRepository
 import kotlinx.coroutines.flow.Flow
 import org.koin.core.annotation.KoinViewModel
 
+/**
+ * ViewModel for retrieving a single museum object by its ID.
+ * Injected as ViewModel via @KoinViewModel annotation.
+ */
 @KoinViewModel
 class DetailViewModel(private val museumRepository: MuseumRepository) : ViewModel() {
     fun getObject(objectId: Int): Flow<MuseumObject?> =

--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/screens/list/ListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/screens/list/ListViewModel.kt
@@ -7,7 +7,9 @@ import com.jetbrains.kmpapp.data.MuseumRepository
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
+import org.koin.core.annotation.KoinViewModel
 
+@KoinViewModel
 class ListViewModel(museumRepository: MuseumRepository) : ViewModel() {
     val objects: StateFlow<List<MuseumObject>> =
         museumRepository.getObjects()

--- a/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/screens/list/ListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/screens/list/ListViewModel.kt
@@ -9,6 +9,10 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import org.koin.core.annotation.KoinViewModel
 
+/**
+ * ViewModel exposing the list of museum objects as a StateFlow.
+ * Injected as ViewModel via @KoinViewModel annotation.
+ */
 @KoinViewModel
 class ListViewModel(museumRepository: MuseumRepository) : ViewModel() {
     val objects: StateFlow<List<MuseumObject>> =

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-ktor = { group = "io.coil-kt.coil3", name = "coil-network-ktor3", version.ref = "coil" }
 koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
+koin-annotations = { module = "io.insert-koin:koin-annotations", version.ref = "koin" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,16 @@
 [versions]
-agp = "8.9.3"
-androidx-activityCompose = "1.10.1"
-androidx-ui-tooling = "1.7.8"
-coil = "3.2.0"
-compose-multiplatform = "1.8.2"
-koin = "4.1.0"
-kotlin = "2.2.0"
-ktor = "3.1.3"
+agp = "8.13.2"
+androidx-activityCompose = "1.12.2"
+androidx-ui-tooling = "1.10.1"
+coil = "3.3.0"
+compose-multiplatform = "1.10.0"
+koin = "4.2.0-beta4"
+koin-plugin = "0.2.8"
+kotlin = "2.3.20-Beta1"
+ktor = "3.3.3"
 materialIconsCore = "1.7.3"
-navigationCompose = "2.9.0-beta03"
-lifecycleCompose = "2.9.1"
+navigationCompose = "2.9.1"
+lifecycleCompose = "2.9.6"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
@@ -18,7 +19,6 @@ androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-ktor = { group = "io.coil-kt.coil3", name = "coil-network-ktor3", version.ref = "coil" }
 koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
-koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
@@ -34,3 +34,4 @@ composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "k
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinxSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+koin = { id = "io.insert-koin.compiler.plugin", version.ref = "koin-plugin" }


### PR DESCRIPTION
Hello,

Here is a proposal to use the new Koin Plugin for Annotations. The Koin Plugin Compiler helps us use few annotations around (`@Singleton`, `@KoinViewModel`...) to structure things. Also possibility to scan definitions into one or more modules, depending on whether you want a simpler Module config. Also demoing `@Configuration` and `@KoinApplication` to help discover configurations.

No KSP, just Kotlin Compiler. Simple setup.

Compile safety is not yet available, but Plugin logs are available already to understand how Annotations & Modules are gathered.

Happy to help follow up. If you want a "annotation" oriented example.