### PR TITLE
Add repositories section to module.yaml

### DIFF
--- a/shared/module.yaml
+++ b/shared/module.yaml
@@ -2,6 +2,12 @@ product:
   type: lib
   platforms: [jvm, android, iosArm64, iosSimulatorArm64, iosX64]
 
+repositories:
+  - https://repo.spring.io/ui/native/release
+  - url: https://dl.google.com/dl/android/maven2/
+  - id: jitpack
+    url: https://jitpack.io
+
 dependencies: 
   - $compose.runtime
   - $compose.foundation

--- a/shared/module.yaml
+++ b/shared/module.yaml
@@ -3,11 +3,7 @@ product:
   platforms: [jvm, android, iosArm64, iosSimulatorArm64, iosX64]
 
 repositories:
-  - https://repo.spring.io/ui/native/release
-  - https://repo.maven.apache.org/maven2/
   - url: https://dl.google.com/dl/android/maven2/
-  - id: jitpack
-    url: https://jitpack.io
 
 dependencies: 
   - $compose.runtime

--- a/shared/module.yaml
+++ b/shared/module.yaml
@@ -4,6 +4,7 @@ product:
 
 repositories:
   - https://repo.spring.io/ui/native/release
+  - https://repo.maven.apache.org/maven2/
   - url: https://dl.google.com/dl/android/maven2/
   - id: jitpack
     url: https://jitpack.io


### PR DESCRIPTION
Without specifying repositories section the command `./amper build` fail on retrieving the dependencies. 

The call on `https://repo1.maven.org/maven2/` return a status `429`.