### PR TITLE
Bump dependency versions

### DIFF
--- a/androidApp/module.yaml
+++ b/androidApp/module.yaml
@@ -7,6 +7,8 @@ dependencies:
   - $libs.ktor.client.okhttp
 
 settings:
+  kotlin:
+    version: 2.4.10 # TODO remove once the default catches up
   compose:
     enabled: true
   android:

--- a/iosApp/module.yaml
+++ b/iosApp/module.yaml
@@ -6,4 +6,6 @@ dependencies:
   - ../shared
 
 settings:
+  kotlin:
+    version: 2.4.10 # TODO remove once the default catches up
   compose: enabled

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 androidx-activity = "1.13.0"
-androidx-lifecycle = "2.10.0"
+androidx-lifecycle = "2.11.0-beta01"
 androidx-navigation = "2.9.2"
-coil = "3.4.0"
+coil = "3.5.0"
 compose-material-icons = "1.7.3"
-koin = "4.2.1"
-kotlinx-coroutines = "1.8.1"
-ktor = "3.4.3"
+koin = "4.2.2"
+kotlinx-coroutines = "1.11.0"
+ktor = "3.5.1"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }

--- a/shared/module.yaml
+++ b/shared/module.yaml
@@ -30,4 +30,5 @@ settings:
     resources:
       packageName: kmp_app_template.shared.generated.resources
   kotlin:
+    version: 2.4.10 # TODO remove once the default catches up
     serialization: json


### PR DESCRIPTION
Bumps the shared dependency versions across the sample.

Only versions the sample already declares are touched. Kotlin, Gradle, AGP and
Compose come from the Kotlin Toolchain CLI rather than the catalog, so they are
not part of this change.
